### PR TITLE
regular screenshot notifications, optional jpg duplicates, video recording for long clicks, prevention of random screenshots

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,10 +31,15 @@ SOURCES		:=	source
 #---------------------------------------------------------------------------------
 ARCH	:=	-march=armv8-a+crc+crypto -mtune=cortex-a57 -mtp=soft -fPIE
 
-CFLAGS	:=	-g -Wall -Wextra -Wpedantic -Werror -O2 -ffunction-sections \
-			$(ARCH) $(DEFINES)
+CFLAGS	:=	-g -Wall -Wextra -Wpedantic -Werror -Os -ffunction-sections \
+			$(ARCH) $(DEFINES) -Wno-pedantic -Wno-missing-field-initializers
 
 CFLAGS	+=	$(INCLUDE) -D__SWITCH__
+
+# For no jpg duplicates (optional)
+NO_JPG_DIRECTIVE := 1
+CFLAGS += -DNO_JPG_DIRECTIVE=$(NO_JPG_DIRECTIVE)
+
 
 CXXFLAGS	:= $(CFLAGS) -fno-rtti -fno-exceptions -std=c++20
 

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -268,7 +268,7 @@ int main() {
                 // If button was not already held, start holding
                 held = true;
                 //capsscOpenRawScreenShotReadStream(nullptr, nullptr, nullptr, ViLayerStack_Default, 100'000'000);
-                initialOpen = true;
+                //initialOpen = true;
                 start_tick = armGetSystemTick();
             }
             else

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -368,7 +368,7 @@ int main() {
     while (true)
     {
         // Check for button press event
-        if (R_SUCCEEDED(eventWait(&event, 100000000))) // Wait for a short time to capture quick presses
+        if (R_SUCCEEDED(eventWait(&captureButtonEvent, 3600000000000))) // increased to 1 hour (longer the better here)
         {
             eventClear(&event);
             //if (initialOpen) {

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -368,7 +368,7 @@ int main() {
     while (true)
     {
         // Check for button press event
-        if (R_SUCCEEDED(eventWait(&captureButtonEvent, 3600000000000))) // increased to 1 hour (longer the better here)
+        if (R_SUCCEEDED(eventWait(&captureButtonEvent, UINT64_MAX))) // await indefinetly
         {
             eventClear(&event);
             //if (initialOpen) {


### PR DESCRIPTION
I made a number of fixes to make the project work with less issues.  When the next version of Ultrahand is released, your current implementation will end up taking pictures every time the project opens (because of the event filter logic).

The issue is with `captureButtonEvent` which can be triggered whenever any other project initializes a captureButton instance.  When a click is made, there are 2 captureButtonEvents.  One for the click, another for the release.  What I ended up doing was making my project initialize itself with 2 extremely quick capture button events so that projects like BMPPrinter and PNGShot can distinguish what is the start of a capture event and what is just an event initialization.

I made these corrections for PNGShot initially, but since they also apply here I thought that it could help your project out a bit.  If you want me to explain some more of the corrected logic on the implementation just let me know.

You can also use
```
NO_JPG_DIRECTIVE := 1
CFLAGS += -DNO_JPG_DIRECTIVE=$(NO_JPG_DIRECTIVE)
```
 in the Makefile or comment it out depending on if you want it to preserve jpg duplicates or not on the build.